### PR TITLE
ci: fix duplicate workflow runs and gate Docker by tag

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,12 +1,14 @@
 name: ci
 
 on:
-    push:
-      branches: [ "main" ]
-      # Publish semver tags as releases.
-      tags: [ 'v*.*.*' ]
-    pull_request:
-      branches: [ "main" ]
+  push:
+    branches: [main]
+    tags: ['v*']
+  pull_request:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 permissions:
   contents: write


### PR DESCRIPTION
## Summary
- Remove branch filter from pull_request trigger
- Add concurrency group to cancel superseded runs
- Docker push already tag-gated, no changes needed

## Test plan
- [ ] Verify PRs trigger CI once (not twice)
- [ ] Verify Docker push only happens on tag push